### PR TITLE
Fix documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ ts_m2fpga
 ├── src
 │   ├── m2fpga.lvproj
 │   ├── mainFPGA.vi
-│   ├── moduleRelays.vi
-│   ├── moduleDaq.vi
-│   ├── moduleIlc.vi
+│   ├── switchRelays.vi
+│   ├── readDaq.vi
+│   ├── ilcCommmunication.vi
 ├── doc
 │   ├── versionHistory.md
-│   ├── moduleRelays.md
-│   ├── moduleDaq.md
-│   ├── moduleIlc.md
+│   ├── switchRelays.md
+│   ├── readDaq.md
+│   ├── ilcCommmunication.md
 ├── fpgaInterface
 │   ├── NiFpga_mainFPGA.h
 │   ├── NiFpga_mainFPGA.lvbitx

--- a/doc/switchRelays.md
+++ b/doc/switchRelays.md
@@ -44,13 +44,16 @@ The following table describes the meaning of each bit in the `controlRelay` cont
 |  2  | Disable cRIO Interlock | Enable cRIO Interlock |
 |  3  | Default value of Reset Power Motor Breakers | Reset Power Motor Breakers |
 |  4  | Default value of Reset Communication Power Breakers | Reset Communication Power Breakers |
-|  5  | Spare | Spare |
+|  5  | Simulation Mode Off | Simulation Mode On |
 |  6  | Spare | Spare |
 |  7  | Spare | Spare |
 
 where `ILC` stands for inner loop controller.
 
 After putting bits 3 and 4 to be 1 is necessary put them back to 0 in the next functional call, to avoid power motor and communication power breakers continuing to reset.
+
+Bit 5 allows setting the `Simulation Mode`.
+This mode will allow FPGA code to interact with simulated sensors data when bit 5 is On, and with real sensors data when bit 5 is Off.
 
 ## Control Relay Debugging
 
@@ -83,4 +86,6 @@ Its type is `uint8_t`.
 
 Session must be closed when no longer needed.
 
-The C/C++ developer needs to code the bits of `controlRelay` and decode the bits of `debugControlRelays` in his side.
+The FPGA code will decode the `controlRelay` integer value from C/C++ interface, override the previous input (if any), and transmit to the hardware directly.
+This implies the C/C++ developer needs to track the previous input actively.
+The `debugControlRelays` can be used to check the current value in FPGA for the debugging purpose.

--- a/doc/switchRelays.md
+++ b/doc/switchRelays.md
@@ -69,7 +69,7 @@ Here is an example how to read a value in the indicator using C/C++:
 
 ```c 
 uint8_t value = 0; /* Declare the value variable */
-NiFpga_ReadU8(session, NiFpga_mainFPGA_IndicatorU8_debugControlRelays = 0x18006, &value);
+NiFpga_ReadU8(session, NiFpga_mainFPGA_IndicatorU8_debugControlRelays, &value);
 ```
 
 where `session` handles a currently session FPGA, opened with:
@@ -82,3 +82,5 @@ and `value` outputs what was read.
 Its type is `uint8_t`.
 
 Session must be closed when no longer needed.
+
+The C/C++ developer needs to code the bits of `controlRelay` and decode the bits of `debugControlRelays` in his side.

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,5 +1,11 @@
 # Version History
 
+0.0.2
+
+- Fix wrong vi names in directory structure of `README.md` file.
+- Fix C example in `Control Relay Debugging` section of `switchRelays.md` file.
+- Add a note at the end of `switchRelays.md` file.
+
 0.0.1
 
 - Add README.md, versionHistory.md, switchRelays.md, readDaq.md, and ilcCommunication.md.


### PR DESCRIPTION
- Fix vi names in `README.md`
- Fix C example in `switchRelay.md` file
- Add a note at the end of `switchRealys.md`.